### PR TITLE
Endpoints/market vendors index

### DIFF
--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -6,7 +6,12 @@ module Api
       end
 
       def show
-        render json: Market.find(params[:id])
+        if Market.exists?(params[:id])
+          render json: Market.find(params[:id])
+        else
+          render json: { errors: "Couldn't find Market with 'id'=#{params[:id]}" }, status: :not_found
+        end
+        
       end
     end
   end

--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V0
+    class VendorsController < ApplicationController
+      def index
+        if Market.exists?(params[:market_id])
+          render json: Market.find(params[:market_id]).vendors
+        else
+          render json: { errors: "Couldn't find Market with 'id'=#{params[:market_id]}" }, status: :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -1,3 +1,5 @@
 class Market < ApplicationRecord
   validates :name, :street, :city, :county, :state, :zip, :lat, :lon, presence: true
+  has_many :market_vendors
+  has_many :vendors, through: :market_vendors
 end

--- a/app/models/market_vendor.rb
+++ b/app/models/market_vendor.rb
@@ -1,0 +1,5 @@
+class MarketVendor < ApplicationRecord
+  belongs_to :market
+  belongs_to :vendor
+  validates :market_id, :vendor_id, presence: true
+end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -1,6 +1,6 @@
 class Vendor < ApplicationRecord
-  validates :name, :description, :contact_name, :contact_phone, :credit_accepted, presence: true
-  validates :credit_accepted, inclusion: [true, false], exclusion: { in:[nil] }
+  validates :name, :description, :contact_name, :contact_phone, presence: true
+  validates :credit_accepted, inclusion: [true, false]
 
   has_many :market_vendors
   has_many :markets, through: :market_vendors

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -1,0 +1,4 @@
+class Vendor < ApplicationRecord
+  validates :name, :description, :contact_name, :contact_phone, :credit_accepted, presence: true
+  validates :credit_accepted, inclusion: [true, false]
+end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -1,4 +1,7 @@
 class Vendor < ApplicationRecord
   validates :name, :description, :contact_name, :contact_phone, :credit_accepted, presence: true
   validates :credit_accepted, inclusion: [true, false]
+
+  has_many :market_vendors
+  has_many :markets, through: :market_vendors
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -1,6 +1,6 @@
 class Vendor < ApplicationRecord
   validates :name, :description, :contact_name, :contact_phone, :credit_accepted, presence: true
-  validates :credit_accepted, inclusion: [true, false]
+  validates :credit_accepted, inclusion: [true, false], exclusion: { in:[nil] }
 
   has_many :market_vendors
   has_many :markets, through: :market_vendors

--- a/spec/factories/markets.rb
+++ b/spec/factories/markets.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :market do
-    name { Faker::Cosmere.allomancer }
+    name { Faker::Company.name }
     street { Faker::Address.street_address }
     city { Faker::Address.city }
-    county { Faker::Cosmere.spren }
+    county { Faker::Fantasy::Tolkien.location }
     state { Faker::Address.state }
     zip { Faker::Address.zip }
     lat { Faker::Address.latitude }

--- a/spec/factories/markets.rb
+++ b/spec/factories/markets.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 FactoryBot.define do
   factory :market do
     name { Faker::Cosmere.allomancer }

--- a/spec/factories/vendors.rb
+++ b/spec/factories/vendors.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :vendor do
-    name { Faker::Cosmere.allomancer }
-    description { Faker::Address.street_address }
-    contact_name { Faker::Address.city }
-    contact_phone { Faker::Cosmere.spren }
-    credit_accepted { Faker::Address.state }
+    name { Faker::Company.name }
+    description { Faker::Fantasy::Tolkien.poem }
+    contact_name { Faker::Fantasy::Tolkien.character }
+    contact_phone { Faker::PhoneNumber.phone_number }
+    credit_accepted { Faker::Boolean.boolean }
   end
 end

--- a/spec/factories/vendors.rb
+++ b/spec/factories/vendors.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :vendor do
+    name { Faker::Cosmere.allomancer }
+    description { Faker::Address.street_address }
+    contact_name { Faker::Address.city }
+    contact_phone { Faker::Cosmere.spren }
+    credit_accepted { Faker::Address.state }
+  end
+end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -11,4 +11,8 @@ RSpec.describe Market, type: :model do
     it { should validate_presence_of(:lat) }
     it { should validate_presence_of(:lon) }
   end
+  describe 'relationships' do
+    it { should have_many(:market_vendors) }
+    it { should have_many(:vendors).through(:market_vendors) }
+  end
 end

--- a/spec/models/market_vendor_spec.rb
+++ b/spec/models/market_vendor_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe MarketVendor, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:market_id) }
+    it { should validate_presence_of(:vendor_id) }
+  end
+  describe 'relationships' do
+    it { should belong_to(:market) }
+    it { should belong_to(:vendor) }
+  end
+end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Vendor, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:contact_name) }
+    it { should validate_presence_of(:contact_phone) }
+    it { should validate_presence_of(:credit_accepted) }
+  end
+end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -8,4 +8,8 @@ RSpec.describe Vendor, type: :model do
     it { should validate_presence_of(:contact_phone) }
     it { should validate_presence_of(:credit_accepted) }
   end
+  describe 'relationships' do
+    it { should have_many(:market_vendors) }
+    it { should have_many(:markets).through(:market_vendors) }
+  end
 end

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Vendor, type: :model do
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:contact_name) }
     it { should validate_presence_of(:contact_phone) }
-    it { should validate_presence_of(:credit_accepted) }
+    it { should allow_values(true, false).for(:credit_accepted) }
   end
   describe 'relationships' do
     it { should have_many(:market_vendors) }

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Markets Endpoints" do
       market_vendor2 = MarketVendor.create({ market_id: @market.id, vendor_id: @vendor2.id})
     end
     it 'sends a list of all Vendors that belong to the given Market' do 
-      get "/api/v0/markets/#{market.id}/vendors"
+      get "/api/v0/markets/#{@market.id}/vendors"
 
       expect(response).to be_successful
 
@@ -121,7 +121,7 @@ RSpec.describe "Markets Endpoints" do
         expect(vendor).to have_key(:contact_phone)
         expect(vendor[:contact_phone]).to be_a(String)
         expect(vendor).to have_key(:credit_accepted)
-        expect(vendor[:credit_accepted]).to be_a(Boolean)
+        expect(vendor[:credit_accepted]).to be(true).or be(false)
       end
     end
     describe 'requesting a Markets vendors with an ID not in the database' do 

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -90,4 +90,14 @@ RSpec.describe "Markets Endpoints" do
       end
     end
   end
+  describe 'Market Vendors Index endpoint (/api/v0/markets/:market_id/vendors)' do 
+    it 'sends a list of all Vendors that belong to the given Market' do 
+      market = create(:market)
+      
+      get "/api/v0/markets/#{market.id}/vendors"
+
+      expect(response).to be_successful
+
+    end
+  end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -91,13 +91,46 @@ RSpec.describe "Markets Endpoints" do
     end
   end
   describe 'Market Vendors Index endpoint (/api/v0/markets/:market_id/vendors)' do 
+    before(:each) do 
+      @market = create(:market)
+      @vendor1 = create(:vendor)
+      @vendor2 = create(:vendor)
+      @vendor3 = create(:vendor)
+      @vendor4 = create(:vendor)
+      market_vendor1 = MarketVendor.create({ market_id: @market.id, vendor_id: @vendor1.id})
+      market_vendor2 = MarketVendor.create({ market_id: @market.id, vendor_id: @vendor2.id})
+    end
     it 'sends a list of all Vendors that belong to the given Market' do 
-      market = create(:market)
-      
       get "/api/v0/markets/#{market.id}/vendors"
 
       expect(response).to be_successful
 
+      market_vendors = JSON.parse(response.body, symbolize_names: true)
+
+      expect(market_vendors.count).to eq(2)
+
+      market_vendors.each do |vendor|
+        expect(vendor).to have_key(:id)
+        expect(vendor[:id]).to be_an(Integer)
+        expect(vendor).to have_key(:name)
+        expect(vendor[:name]).to be_a(String)
+        expect(vendor).to have_key(:description)
+        expect(vendor[:description]).to be_a(String)
+        expect(vendor).to have_key(:contact_name)
+        expect(vendor[:contact_name]).to be_a(String)
+        expect(vendor).to have_key(:contact_phone)
+        expect(vendor[:contact_phone]).to be_a(String)
+        expect(vendor).to have_key(:credit_accepted)
+        expect(vendor[:credit_accepted]).to be_a(Boolean)
+      end
+    end
+    describe 'requesting a Markets vendors with an ID not in the database' do 
+      it 'returns a 404 error with a message' do
+        get "/api/v0/markets/99999/vendors"
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to eq("errors"=>"Couldn't find Market with 'id'=99999")
+      end
     end
   end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -81,5 +81,13 @@ RSpec.describe "Markets Endpoints" do
       expect(market).to have_key(:lon)
       expect(market[:lon]).to be_a(String)
     end
+    describe 'requesting a Market not in the database' do 
+      it 'returns a 404 error with a message' do
+        get "/api/v0/markets/99999"
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to eq("errors"=>"Couldn't find Market with 'id'=99999")
+      end
+    end
   end
 end


### PR DESCRIPTION
add endpoint for '/api/v0/markets/:market_id/vendors'
sends a list of all vendors associated with the given market.
added models for Vendor and MarketVendor, includes validations and relationships. add factories and specs for both new models.
tested happy and sad path results for market vendors endpoint.